### PR TITLE
Mint 22.1 added, instruction to umask 0022

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options
   -us1,--user-skins1		user skins1
   -ua,--user-application	user application
   -sa,--samba			samba
+
 ```
 List of currently OpenSSL 1.0.x supported devices (BOX_TYPE): 1240E 300E 3272 3370 3390 4020 450E 540E 546E 6430 6490 6590 6810 6840 7240 7270v2 7270v3 7272 7312 7320 7320-Alien7330 7330 7330SL 7340 7360v1 7360v2 7362 7369 7390 7412 7581 7582 DVB-C
 ```
@@ -86,3 +87,10 @@ Push the create image to the Fritz!Box 7490, use this command
 Create your own toolchains
 ```
 ./i-matik create
+
+## Installation 
+Set umask 0022 before you clone this repository
+```
+umask 0022
+git clone https://github.com/MasterRoCcO/i-matik.git
+```

--- a/support/i-matik/instal_check/instal_check
+++ b/support/i-matik/instal_check/instal_check
@@ -2,7 +2,7 @@
 
 # Define the OS version and supported versions
 OS_VERSION=$(lsb_release -rs)
-SUPPORTED_VERSIONS=("20.04" "21.10" "22.04" "23.04" "23.10" "24.04" "10" "11" "12" "2023.4" "2024.1" "2024.3" "21.3" "22" "17" "7.1")
+SUPPORTED_VERSIONS=("20.04" "21.10" "22.04" "23.04" "23.10" "24.04" "10" "11" "12" "2023.4" "2024.1" "2024.3" "21.3" "22" "22.1" "17" "7.1")
 
 # Check if the current OS version is supported
 if [[ " ${SUPPORTED_VERSIONS[@]} " =~ " ${OS_VERSION} " ]]; then
@@ -61,6 +61,7 @@ fi
 # 2024.3 = Kali
 # 21.3   = Mint
 # 22     = Mint
+# 22.1   = Mint
 # 7.1	= elementary
 
 # all OS tested


### PR DESCRIPTION
Hi and thanks for this great piece of coding art.

"22.1" added to the allowed distributios (Mint 22.1 Xia, building worked well for 8.02 for 7590 and 7690)
"Install instructions" added to the readme.


Cheerz
Schnoog